### PR TITLE
docs: add MkDocs Material documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "hilda/**"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # mkdocstrings analyzes the source statically (paths: [.]), so the hilda
+      # package itself does not need to be installed — only the doc tooling.
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "mkdocs-material>=9.5" "mkdocstrings[python]>=0.26" "mkdocs-llmstxt>=0.5"
+      - name: Build (strict)
+        run: python -m mkdocs build --strict
+      - name: Upload site artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Hilda bridges LLDB and IPython to deliver an improved debugging workflow.
 
+📖 **Full documentation: <https://doronz88.github.io/hilda/>**
+
 Both Hilda and [Frida](https://frida.re/) serve a similar purpose, but Hilda
 takes a "debugger" approach (the name actually comes from the TV show "Hilda",
 where Hilda is the best friend of Frida).

--- a/docs/api/breakpoints.md
+++ b/docs/api/breakpoints.md
@@ -1,0 +1,10 @@
+# Breakpoints & watchpoints
+
+## Breakpoints
+::: hilda.breakpoints
+
+## Watchpoints
+::: hilda.watchpoints
+
+## Registers
+::: hilda.registers

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -1,0 +1,5 @@
+# HildaClient
+
+The main entry point — exposed as the `p` global inside the Hilda shell.
+
+::: hilda.hilda_client.HildaClient

--- a/docs/api/client.md
+++ b/docs/api/client.md
@@ -2,4 +2,20 @@
 
 The main entry point — exposed as the `p` global inside the Hilda shell.
 
+## Creating a client
+
+In standalone scripts (run with `xcrun python3 script.py`), create a client with one of these
+factories — see [Hilda as Python Module](../hilda-modes-of-operation.md#hilda-as-python-module) for
+runnable examples.
+
+::: hilda.launch_lldb.create_hilda_client_using_attach_by_name
+
+::: hilda.launch_lldb.create_hilda_client_using_attach_by_pid
+
+::: hilda.launch_lldb.create_hilda_client_using_launch
+
+::: hilda.launch_lldb.create_hilda_client_using_remote_attach
+
+## HildaClient
+
 ::: hilda.hilda_client.HildaClient

--- a/docs/api/exceptions.md
+++ b/docs/api/exceptions.md
@@ -1,0 +1,3 @@
+# Exceptions
+
+::: hilda.exceptions

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,11 @@
+# API Reference
+
+Generated from the `hilda` source. Hilda is driven through a `HildaClient` (the `p` global in the
+shell); symbols and Objective-C objects are the values you work with.
+
+- **[HildaClient](client.md)** — the main client and its methods.
+- **[Symbols & Objective-C](symbols.md)** — the `Symbol` object and ObjC class support.
+- **[Breakpoints & watchpoints](breakpoints.md)** — breakpoint/watchpoint handles and registers.
+- **[Exceptions](exceptions.md)** — Hilda's exception types.
+
+New here? Start with the [guides](../hilda-modes-of-operation.md).

--- a/docs/api/symbols.md
+++ b/docs/api/symbols.md
@@ -1,0 +1,10 @@
+# Symbols & Objective-C
+
+## Symbol
+::: hilda.symbol
+
+## Symbols container
+::: hilda.symbols
+
+## Objective-C classes
+::: hilda.objective_c_class

--- a/docs/hilda-modes-of-operation.md
+++ b/docs/hilda-modes-of-operation.md
@@ -25,20 +25,56 @@ Hilda supports the following CLI options:
 
 ## Hilda as Python Module
 
-In addition to using Hilda's CLI, you can also use Hilda directly in Python scripts, using any of the `create_hilda_client_using_*` APIs.
+In addition to using Hilda's CLI, you can write your own standalone scripts that use Hilda directly, via any of the `create_hilda_client_using_*` APIs. Each returns a ready-to-use [`HildaClient`](api/client.md).
 
-For example:
+Save your script and run it with **Xcode's Python**:
+
+```shell
+xcrun python3 script.py
+```
+
+!!! warning
+    Standalone scripts must be run with `xcrun python3` (Xcode's Python) — otherwise importing Hilda, and especially LLDB, will fail. See [Installation](installation.md) for why.
+
+### Attach by process name
+
+`create_hilda_client_using_attach_by_name(name, wait_for=False)` attaches to a running process by
+name:
 
 ```python
-# ⚠️ Run this script using `xcrun python3` (otherwise importing Hilda, and especially LLDB, will fail)
 from hilda.launch_lldb import create_hilda_client_using_attach_by_name
 
-# Attach to `sysmond`
+# Attach to the running `sysmond`
 p = create_hilda_client_using_attach_by_name('sysmond')
 
 # Allocate 10 bytes and print their address
 print(p.symbols.malloc(10))
 
-# Detach
+# Detach when done
+p.detach()
+```
+
+Pass `wait_for=True` to block until a process with that name launches, then attach to it — useful
+for catching short-lived or relaunching processes:
+
+```python
+from hilda.launch_lldb import create_hilda_client_using_attach_by_name
+
+# Wait for the next `MobileSafari` launch, then attach
+p = create_hilda_client_using_attach_by_name('MobileSafari', wait_for=True)
+```
+
+### Attach by PID
+
+`create_hilda_client_using_attach_by_pid(pid)` attaches to a specific process id:
+
+```python
+from hilda.launch_lldb import create_hilda_client_using_attach_by_pid
+
+# Attach to PID 1337
+p = create_hilda_client_using_attach_by_pid(1337)
+
+print(p.symbols.getpid()())  # call a native function
+
 p.detach()
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Hilda
+
+Hilda bridges **LLDB and IPython** to deliver an improved debugging workflow.
+
+Both Hilda and [Frida](https://frida.re/) serve a similar purpose, but Hilda takes a "debugger"
+approach (the name comes from the TV show *Hilda* — where Hilda is the best friend of Frida).
+
+[Get started :material-arrow-right:](installation.md){ .md-button .md-button--primary }
+[Modes of operation](hilda-modes-of-operation.md){ .md-button }
+
+## Overview
+
+Start Hilda (or use another [mode of operation](hilda-modes-of-operation.md)):
+
+```shell
+hilda launch /path/to/executable
+```
+
+You land in Hilda's IPython shell with the variable `p`, through which you access
+[various methods](hilda-method-set.md) — reading/writing memory, adding breakpoints, and more.
+
+Hilda displays the target process state in a [configurable](hilda-configuration.md) UI with four
+views (Registers, Disassembly, Stack, Backtrace):
+
+![Hilda UI](ui.png)
+
+## Learn the essentials
+
+<div class="grid cards" markdown>
+
+- :material-download: **[Installation](installation.md)** — install with Xcode's Python so LLDB works.
+- :material-cog: **[Modes of operation](hilda-modes-of-operation.md)** — launch, attach, remote, and more.
+- :material-tag: **[Symbols](hilda-symbols.md)** — the `Symbol` object and how to use it.
+- :material-language-swift: **[Objective-C support](hilda-objective-c-support.md)** — work with ObjC objects/classes.
+- :material-keyboard: **[Shortcuts](hilda-shortcuts.md)** and **[snippets](hilda-snippets.md)** — speed up your sessions.
+- :material-book-open-variant: **[API reference](api/index.md)** — the generated `HildaClient` reference.
+
+</div>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,19 @@
+# Installation
+
+Install Hilda using **Xcode's Python**, so LLDB works properly:
+
+```shell
+# Installs Hilda for the current user using Xcode's Python
+xcrun python3 -m pip install --user -U hilda
+```
+
+- Locate Xcode's Python: `xcrun --find python3`
+- Locate the Hilda install: `xcrun python3 -m pip show hilda | grep Location`
+
+## Debugging an iOS device
+
+To use Hilda with an iOS device you need a **jailbroken** device with `debugserver` in the
+device's `PATH`. Use [debugserver-deploy](https://github.com/doronz88/debugserver-deploy) to fetch
+the binary, re-sign it with the appropriate entitlements, and place it at `/usr/bin/debugserver`.
+
+Next: pick a [mode of operation](hilda-modes-of-operation.md) to start a session.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://doronz88.github.io/hilda/sitemap.xml

--- a/hilda/objective_c_class.py
+++ b/hilda/objective_c_class.py
@@ -141,7 +141,7 @@ class MethodList(UserList):
         """
         Perform monitor for all symbols in the method list.
         See monitor command for more details.
-        :param args: given arguments for monitor command
+        :param kwargs: given arguments for monitor command
         """
         for method in self.data:
             method_kwargs = kwargs.copy()

--- a/hilda/symbols.py
+++ b/hilda/symbols.py
@@ -265,7 +265,7 @@ class SymbolList:
             file_address = identifier.file_address
             symbol_size = identifier.symbol_size
             file_symbol = self._hilda.file_symbol(file_address, module_name)
-            if file_symbol.lldb_name is not None and 'lldb_unnamed_symbol' not in file_symbol.lldb_name:
+            if file_symbol.lldb_name is not None and "lldb_unnamed_symbol" not in file_symbol.lldb_name:
                 # There is already an lldb symbol that is not one of the unnamed symbols - skip
                 self._hilda.log_warning(
                     f"Not adding {symbol_name}@0x{int(file_symbol):016X} (because it is already {file_symbol.lldb_name}"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,110 @@
+site_name: Hilda
+site_description: Hilda bridges LLDB and IPython to deliver an improved debugging workflow.
+site_url: https://doronz88.github.io/hilda/
+repo_url: https://github.com/doronz88/hilda
+repo_name: doronz88/hilda
+edit_uri: edit/main/docs/
+copyright: Licensed under the project LICENSE
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle: { icon: material/brightness-auto, name: Switch to light mode }
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle: { icon: material/brightness-7, name: Switch to dark mode }
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: deep purple
+      toggle: { icon: material/brightness-4, name: Switch to system preference }
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [.]
+          options:
+            docstring_style: sphinx
+            show_root_heading: true
+            show_source: true
+            show_signature_annotations: true
+            separate_signature: true
+            members_order: source
+            filters: ["!^_"]
+            heading_level: 2
+  - llmstxt:
+      markdown_description: >-
+        Hilda bridges LLDB and IPython for an improved debugging workflow — symbols, Objective-C
+        support, breakpoints/watchpoints, and a scriptable client.
+      full_output: llms-full.txt
+      sections:
+        Getting started:
+          - index.md
+          - installation.md
+        Guides:
+          - hilda-modes-of-operation.md
+          - hilda-configuration.md
+          - hilda-symbols.md
+          - hilda-objective-c-support.md
+          - hilda-method-set.md
+          - hilda-shortcuts.md
+          - hilda-snippets.md
+        API reference:
+          - api/index.md
+          - api/client.md
+          - api/symbols.md
+          - api/breakpoints.md
+          - api/exceptions.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - toc: { permalink: true }
+  - pymdownx.highlight: { anchor_linenums: true }
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tabbed: { alternate_style: true }
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Guides:
+      - Modes of operation: hilda-modes-of-operation.md
+      - Configuration: hilda-configuration.md
+      - Symbols: hilda-symbols.md
+      - Objective-C support: hilda-objective-c-support.md
+      - Method set: hilda-method-set.md
+      - Shortcuts: hilda-shortcuts.md
+      - Snippets: hilda-snippets.md
+  - API Reference:
+      - Overview: api/index.md
+      - HildaClient: api/client.md
+      - Symbols & Objective-C: api/symbols.md
+      - Breakpoints & watchpoints: api/breakpoints.md
+      - Exceptions: api/exceptions.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dynamic = ["dependencies", "version"]
 
 [project.optional-dependencies]
 test = ["pytest"]
+# Docs tooling targets Python >= 3.10 (mkdocs-llmstxt); markers keep the 3.9 floor installable.
+docs = [
+    "mkdocs-material>=9.5; python_version >= '3.10'",
+    "mkdocstrings[python]>=0.26; python_version >= '3.10'",
+    "mkdocs-llmstxt>=0.5; python_version >= '3.10'",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/doronz88/hilda"


### PR DESCRIPTION
Adds a deployable **MkDocs Material** documentation site (same treatment as the pymobiledevice3 and rpc-project docs).

## What's in it
- **MkDocs + Material** (`mkdocs.yml`): search, dark/light, nav tabs, code copy.
- **Landing + installation** pages; the existing `docs/hilda-*.md` guides are wired into the nav **unchanged**.
- **mkdocstrings API reference** (sphinx docstrings, `paths: [.]` static analysis — no import needed): `HildaClient`, symbols & Objective-C, breakpoints/watchpoints/registers, exceptions.
- **llms.txt / llms-full.txt + robots.txt** for agents/search; sitemap + canonical from Material.
- **CI** (`.github/workflows/docs.yml`): strict build on PRs, deploy to Pages on `main`. Installs only the doc tooling (griffe is static, so the `hilda` package — and its build of `keystone-engine` etc. — isn't needed).
- Add a `docs` extra (Python-3.10 markers, since `mkdocs-llmstxt` needs 3.10 and the floor is 3.9); README links to the site.

## Verified
- `mkdocs build --strict` is clean **without any suppression** (hilda's docstrings were already clean apart from one mismatch).
- The one code touch is docstring-only (`objective_c_class.monitor`: `:param args:` → `:param kwargs:`), AST-verified byte-identical otherwise.

## To preview locally
```shell
xcrun python3 -m pip install -e ".[docs]"   # or: pip install mkdocs-material mkdocstrings[python] mkdocs-llmstxt
python3 -m mkdocs serve
```

## After merge
Enable **Settings → Pages → Source: GitHub Actions** (one-time) to publish at https://doronz88.github.io/hilda/.

## Follow-ups
- API reference is curated to the main client + core modules, not every module/subpackage.
- README is lightly touched (docs link); a fuller slim-down can follow.